### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/probedock/probedock.png?label=ready&title=Ready)](https://waffle.io/probedock/probedock)
 # ProbeDock
 
 **Test tracking and analysis tool.**


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/probedock/probedock

This was requested by a real person (user wasadigi) on waffle.io, we're not trying to spam you.